### PR TITLE
Add RSS feed for roasts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -26,11 +26,14 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addFilter("date", (dateObj, format) => {
     const date = new Date(dateObj);
     if (format === "readable") {
-      return date.toLocaleDateString('en-US', { 
-        year: 'numeric', 
-        month: 'long', 
-        day: 'numeric' 
+      return date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
       });
+    }
+    if (format === "rss") {
+      return date.toUTCString();
     }
     return date.toISOString().split('T')[0];
   });

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A static website that generates satirical roasts of database blog posts using th
 - Caches processed articles to avoid duplicate API calls
 - Builds a static HTML site using Eleventy
 - Ready for deployment on GitHub Pages
+- Exposes an RSS feed of roasts at `/feed.xml`
 
 ## Setup Instructions
 
@@ -114,7 +115,8 @@ The static site will be generated in the `_site/` directory.
 ├── _cache/
 │   └── roasts.json     # Cached roasts (auto-generated)
 ├── _site/              # Generated static site (auto-generated)
-└── index.njk           # Homepage template
+├── index.njk           # Homepage template
+└── feed.njk            # RSS feed template
 ```
 
 ## Customization

--- a/feed.njk
+++ b/feed.njk
@@ -1,0 +1,22 @@
+---
+layout: null
+permalink: feed.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>The DB Grill</title>
+    <link>https://db-grill.com/</link>
+    <description>Where database blog posts get flame-broiled to perfection</description>
+    {% for roast in roasts %}
+    <item>
+      <title>{{ roast.title }}</title>
+      <link>https://db-grill.com/roast/{{ roast.slug }}/</link>
+      <guid>https://db-grill.com/roast/{{ roast.slug }}/</guid>
+      <pubDate>{{ roast.pubDate | date("rss") }}</pubDate>
+      <description><![CDATA[{{ roast.roast | markdown | safe }}]]></description>
+    </item>
+    {% endfor %}
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary
- support RSS-style timestamps in Eleventy's date filter
- generate RSS feed of roasts at `/feed.xml`
- document the new RSS feed

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6895bdcdfd10832b96abad7024f2e43a